### PR TITLE
Updated to 2.0.0

### DIFF
--- a/tokumx-bin.rb
+++ b/tokumx-bin.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class TokumxBin < Formula
   homepage "http://www.tokutek.com/products/tokumx-for-mongodb"
-  version "1.5.1"
+  version "2.0.0"
   conflicts_with "mongodb"
   url "https://s3.amazonaws.com/tokumx-2.0.0/tokumx-2.0.0-osx-x86_64-main.tar.gz"
   sha1 "ad575f0868a778bca45eea404346e9823d6d5ef2"

--- a/tokumx-bin.rb
+++ b/tokumx-bin.rb
@@ -4,8 +4,8 @@ class TokumxBin < Formula
   homepage "http://www.tokutek.com/products/tokumx-for-mongodb"
   version "1.5.1"
   conflicts_with "mongodb"
-  url "https://s3.amazonaws.com/tokumx-1.5.1/tokumx-1.5.1-osx-x86_64-main.tar.gz"
-  sha1 "764476c45c97cc51504ace000cc6ec5d6fb275e0"
+  url "https://s3.amazonaws.com/tokumx-2.0.0/tokumx-2.0.0-osx-x86_64-main.tar.gz"
+  sha1 "ad575f0868a778bca45eea404346e9823d6d5ef2"
 
   raise FormulaSpecificationError, 'Formula requires Mavericks or Yosemite (OSX 10.9 or 10.10)' unless MacOS.version >= :mavericks
 

--- a/tokumx-bin.rb
+++ b/tokumx-bin.rb
@@ -14,9 +14,9 @@ class TokumxBin < Formula
     raise CannotInstallFormulaError, "Canceling at user request." unless $?.success?
     email.strip!
     unless email.empty?
-      curl "-X", "POST", "--data-urlencode", "email=#{email}", "--data-urlencode", "source=homebrew", "--data-urlencode", "product=tokumx", "-o", "/dev/null", "-s", "http://www.tokutek.com/simple_create_account.php"
+      exec "curl -X POST --data-urlencode email=#{email} --data-urlencode source=homebrew --data-urlencode product=tokumx -o /dev/null -s http://www.tokutek.com/simple_create_account.php"
     else
-      curl "-X", "POST", "--data-urlencode", "email=anonymous@homebrew-installer.com", "--data-urlencode", "source=homebrew", "--data-urlencode", "product=tokumx", "-o", "/dev/null", "-s", "http://www.tokutek.com/simple_create_account.php"
+      exec "curl -X POST --data-urlencode email=anonymous@homebrew-installer.com --data-urlencode source=homebrew --data-urlencode product=tokumx -o /dev/null -s http://www.tokutek.com/simple_create_account.php"
     end
 
     bin.install Dir["bin/*"]

--- a/tokumx-bin.rb
+++ b/tokumx-bin.rb
@@ -10,15 +10,6 @@ class TokumxBin < Formula
   raise FormulaSpecificationError, 'Formula requires Mavericks or Yosemite (OSX 10.9 or 10.10)' unless MacOS.version >= :mavericks
 
   def install
-    email = `osascript -e 'Tell application "System Events" to display dialog "Provide your email address to keep up with TokuMX news:" default answer "email address"' -e "text returned of result"`
-    raise CannotInstallFormulaError, "Canceling at user request." unless $?.success?
-    email.strip!
-    unless email.empty?
-      exec "curl -X POST --data-urlencode email=#{email} --data-urlencode source=homebrew --data-urlencode product=tokumx -o /dev/null -s http://www.tokutek.com/simple_create_account.php"
-    else
-      exec "curl -X POST --data-urlencode email=anonymous@homebrew-installer.com --data-urlencode source=homebrew --data-urlencode product=tokumx -o /dev/null -s http://www.tokutek.com/simple_create_account.php"
-    end
-
     bin.install Dir["bin/*"]
     lib.install Dir["lib64/*"]
     share.install Dir["scripts"]


### PR DESCRIPTION
Please be aware that this change also removes the curl based user registration. This was more of a bugfixing thing but ended up removing behavior (not the intention). Also, having that breaks the scriptability of the `brew install tokumx-bin` command. 
I would want to recommend the repo owner to keep that in mind and probably come up with some other way of making people register - I just can't think of one at the moment.
